### PR TITLE
Update to 1.9.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8.7-R0.1-SNAPSHOT</version>
+            <version>1.9.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
@@ -7,19 +7,19 @@ public class Instrument {
     public static Sound getInstrument(byte instrument) {
         switch (instrument) {
             case 0:
-                return Sound.NOTE_PIANO;
+                return Sound.BLOCK_NOTE_HARP;
             case 1:
-                return Sound.NOTE_BASS_GUITAR;
+                return Sound.BLOCK_NOTE_BASS;
             case 2:
-                return Sound.NOTE_BASS_DRUM;
+                return Sound.BLOCK_NOTE_BASEDRUM;
             case 3:
-                return Sound.NOTE_SNARE_DRUM;
+                return Sound.BLOCK_NOTE_SNARE;
             case 4:
-                return Sound.NOTE_STICKS;
+                return Sound.BLOCK_NOTE_HAT;
             case 5:
-                return Sound.NOTE_PLING;
+                return Sound.BLOCK_NOTE_PLING;
             default:
-                return Sound.NOTE_PIANO;
+                return Sound.BLOCK_NOTE_HARP;
         }
     }
 
@@ -35,8 +35,9 @@ public class Instrument {
                 return org.bukkit.Instrument.SNARE_DRUM;
             case 4:
                 return org.bukkit.Instrument.STICKS;
+            /* No equivalent instrument for the sound.
             case 5:
-                return org.bukkit.Instrument.PLING;
+                return org.bukkit.Instrument.PLING; */
             default:
                 return org.bukkit.Instrument.PIANO;
         }


### PR DESCRIPTION
Changes include an updated pom.xml to the latest Bukkit and enums remapped to the new ones.

One thing to note is that there is no org.bukkit.Instrument enumeration for PLING so I removed it.